### PR TITLE
Some fixes and information about the default configs and views.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ before it's rendered.
 
 You can use different config files by setting the factory's `$config` parameter.
 
+The `view` key of the config files sets the [view file](http://kohanaframework.org/3.3/guide/kohana/mvc/views) that will be used to render the menu.
+It defaults to a view file based on the `$config` parameter: `/views/templates/menu/$config`
+and if that does not exist falls back on the included `/views/templates/menu/default` view file.
+For an example, see the included `navbar.php` config file.
+
 ### Example: Load menu configuration based on user role
 
 ```php

--- a/classes/Kohana/Menu.php
+++ b/classes/Kohana/Menu.php
@@ -122,7 +122,7 @@ class Kohana_Menu {
 	 * @return Menu
 	 * @since 2.0
 	 */
-	public static function factory($config_file = 'bootstrap')
+	public static function factory($config_file = 'simple')
 	{
 		// Load menu config
 		$menu_config = self::_get_menu_config($config_file);

--- a/config/menu/navbar.php
+++ b/config/menu/navbar.php
@@ -6,7 +6,7 @@
  * @author Ando Roots <ando@sqroot.eu>
  */
 return [
-
+	'view' => 'templates/menu/bootstrap/navbar',
 	'items' => [
 		[
 			'url'     => 'issues',

--- a/views/templates/menu/bootstrap/navbar.php
+++ b/views/templates/menu/bootstrap/navbar.php
@@ -13,7 +13,7 @@
 ?>
 <ul class="nav">
 
-	<?foreach ($menu->get_visible_items() as $item):
+	<?php foreach ($menu->get_visible_items() as $item):
 
 		// Is this a dropdown-menu with sibling links?
 		if ($item->has_siblings()):?>
@@ -24,15 +24,15 @@
 				   data-toggle="dropdown"><?= $item->title ?><b class="caret"></b>
 				</a>
 				<ul class="dropdown-menu">
-					<? foreach ($item->siblings as $subitem): ?>
+					<?php foreach ($item->siblings as $subitem): ?>
 						<li class="<?= $subitem->get_classes() ?>">
 							<?= (string) $subitem ?>
 						</li>
-					<? endforeach ?>
+					<?php endforeach ?>
 				</ul>
 			</li>
 
-		<?
+		<?php
 		else:
 			// No, this is a "normal", single-level menu
 			?>
@@ -40,7 +40,7 @@
 				<?= (string) $item ?>
 			</li>
 
-		<? endif ?>
+		<?php endif ?>
 
-	<? endforeach ?>
+	<?php endforeach ?>
 </ul>

--- a/views/templates/menu/default.php
+++ b/views/templates/menu/default.php
@@ -12,11 +12,10 @@
 ?>
 <nav>
 	<ul>
-		<? foreach ($menu->get_visible_items() as $item): ?>
-
+		<?php foreach ($menu->get_visible_items() as $item): ?>
 			<li class="<?= $item->get_classes() ?>">
 				<?= (string) $item ?>
 			</li>
-		<? endforeach ?>
+		<?php endforeach ?>
 	</ul>
 </nav>


### PR DESCRIPTION
- Documentation of the `view` config key, and include it in `config/menu/navbar.php`;
- Change the default config file to `simple` (which exists) instead of `bootstrap` (which doesn't); and
- Switch to full PHP opening tags instead of short tags (as per [PSR-1](http://www.php-fig.org/psr/psr-1/)).
